### PR TITLE
bump nix from 0.22 to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["process", "workers", "tools"]
 
 [dependencies]
 tokio = { version = "1.9.0", features = ["full"] }
-nix = "0.22.0"
+nix = { version = "0.30", features = ["signal"] }
 sysinfo = "0.29.2"
 log = "0.4.14"
 triggered = "0.1.2"


### PR DESCRIPTION
bump nix version to fix building on loongarch64 
Link: https://github.com/nix-rust/nix/pull/2045